### PR TITLE
FEATURE: $ImagePath based based on ENV

### DIFF
--- a/code/TemplateHelpers.php
+++ b/code/TemplateHelpers.php
@@ -20,7 +20,8 @@ class TemplateHelpers implements TemplateGlobalProvider
             'isTest',
             'isLive',
             'addInlineScript',
-            'ThemeDir'
+            'ThemeDir',
+            'ImagePath'
         );
     }
 
@@ -64,5 +65,20 @@ class TemplateHelpers implements TemplateGlobalProvider
     public static function ThemeDir()
     {
         return 'themes/' . Config::inst()->get('SSViewer', 'theme');
+    }
+
+    public static function ImagePath($imageURL)
+    {
+        $imagesPath = '/themes/' . Config::inst()->get('SSViewer', 'theme');
+        $dev_path = Config::inst()->forClass('TemplateHelpers')->get('dev_images');
+        $prod_path = Config::inst()->forClass('TemplateHelpers')->get('prod_images');
+
+        if (Director::isDev()) {
+            $imagesPath = $imagesPath . $dev_path . $imageURL;
+        } else {
+            $imagesPath = $imagesPath . $prod_path . $imageURL;
+        }
+
+        return $imagesPath;
     }
 }


### PR DESCRIPTION
Adding a helper function to automatic change the image path based on SS env,

You can configure your images dev and prod path in your `config.yml` file under `mysite/_config/config.yml`,

Example:

```
TemplateHelpers:
  dev_images: <dev-images-path>
  prod_images: <prod-images-path>
```

Then, in the view:

```
<img src="$ImagePath("banner/hero.png")">
<img src="$ImagePath("contact-map.png")">
...etc
```

With this feature, we can configure `Gulp`, `Grunt` or any `npm` task to compress our images and generate the "production" level image using the `<img>` tag in the view,

Actually, can be any task runner, just need to output for the correct prod path!

Thanks @stecman for the idea about the YML config

cc @kyle-beattie 

***Inspired by [Rails Pipeline](http://guides.rubyonrails.org/asset_pipeline.html)***